### PR TITLE
Remove the insist require

### DIFF
--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -1,6 +1,5 @@
 require "logstash/logging"
 require 'logstash/devutils/rspec/logstash_helpers'
-require "insist"
 
 if ENV['COVERAGE']
   require 'simplecov'

--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "0.0.6"
+  spec.version = "0.0.7"
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"
   spec.license = "Apache 2.0"


### PR DESCRIPTION
Remove the insist require as it might not be used, so it's something the user of this gem should require and include whenever s/he wants to use this lib.