### PR TITLE
Add insist as a runtime dependency

### DIFF
--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "0.0.6"
+  spec.version = "0.0.7"
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"
   spec.license = "Apache 2.0"
@@ -24,5 +24,11 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rake" # MIT License
   spec.add_runtime_dependency "gem_publisher"  # MIT License
   spec.add_runtime_dependency "minitar" # GPL2|Ruby License
+
+  # Should be removed as soon as the plugins are using insist by their
+  # own, and not relying on being required by the spec helper.
+  # (some plugins does it, some use insist throw spec_helper)
+  spec.add_runtime_dependency "insist", "1.0.0" # (Apache 2.0 license)
+
 end
 


### PR DESCRIPTION
Added insist as a runtime dependency, so plugins that are relying on it being there throw the spec_helper don't raise an issue.

Till now there was not issue because plugins are requiring logstash, and insist was there, but is not going to be there after we merge https://github.com/elasticsearch/logstash/pull/2319
