### PR TITLE
Require logstash/json in the logstash_helper

### DIFF
--- a/lib/logstash/devutils/rspec/logstash_helpers.rb
+++ b/lib/logstash/devutils/rspec/logstash_helpers.rb
@@ -1,6 +1,7 @@
 require "logstash/agent"
 require "logstash/pipeline"
 require "logstash/event"
+require "logstash/json"
 
 module LogStashHelper
 


### PR DESCRIPTION
Logstash::Json is required if you use this construct:

```ruby
sample("message" => "/a/sa/search?rgu=0;+%C3%BB%D3%D0%D5%D2%B5%BD=;+%B7%A2%CB%CD=") do
  expect(subject["message"]).to eq("sdfsfs")
end
```

The specs were failing in the logstash-codec-urldecode