### PR TITLE
Fix rspec dependency type, to it gets installed for test 

### DIFF
--- a/logstash-devutils.gemspec
+++ b/logstash-devutils.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "logstash-devutils"
-  spec.version = "0.0.8"
+  spec.version = "0.0.9"
   spec.summary = "logstash-devutils"
   spec.description = "logstash-devutils"
   spec.license = "Apache 2.0"
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.email = ["jls@semicomplete.com"]
   spec.homepage = "https://github.com/elasticsearch/logstash-devutils"
 
-  spec.add_development_dependency "rspec", "~> 2.14.0" # MIT License
+  spec.add_runtime_dependency "rspec", "~> 2.14.0" # MIT License
   spec.platform = "java"
   spec.add_runtime_dependency "jar-dependencies" # MIT License
 


### PR DESCRIPTION
Fixes https://github.com/elasticsearch/logstash/issues/2663 for all plugins that has a require to logstash-devutils 